### PR TITLE
feat(i18n): persist and initialize language preference from localStorage

### DIFF
--- a/afrin-houses-main/src/i18n.ts
+++ b/afrin-houses-main/src/i18n.ts
@@ -12,18 +12,33 @@ i18n
   .use(initReactI18next)
   // Initialize i18next
   .init({
-    // Default language
-    lng: 'ar',
+    // Default language - check localStorage first
+    lng: localStorage.getItem('language') || 'ar',
     fallbackLng: 'en',
     debug: false,
     // Common namespace used around the app
     ns: ['translation'],
     defaultNS: 'translation',
     supportedLngs: ['en', 'ar'],
+    
+    // Language detection options
+    detection: {
+      // Order of language detection - prioritize localStorage
+      order: ['localStorage', 'navigator', 'htmlTag'],
+      
+      // Keys or params to lookup language from
+      lookupLocalStorage: 'language',
+      
+      // Cache user language - only use localStorage
+      caches: ['localStorage'],
+      
+      // Optional expire and domain for set cookie
+      cookieMinutes: 10080, // 7 days
+    },
+    
     interpolation: {
       escapeValue: false, // React already safes from XSS
     },
-    // Remove the dir: 'rtl' line - we'll handle this in the changeLanguage function
   });
 
 export default i18n;


### PR DESCRIPTION
- Save selected language to localStorage on change
- Initialize language from localStorage if available on app load
- Sync document direction and language attributes with current language
- Add i18next detection options to prioritize localStorage
- Listen for i18n initialization event before setting language
- Use fallback language 'ar' if no preference found in localStorage or i18n
- Remove fixed default language setting from i18n init configuration