### PR TITLE
feat(property): add priceType relation and localization support

### DIFF
--- a/Propenty-management-api-main/app/Http/Controllers/Api/PropertyController.php
+++ b/Propenty-management-api-main/app/Http/Controllers/Api/PropertyController.php
@@ -280,7 +280,7 @@ class PropertyController extends Controller
         ]);
 
         // Load relationships
-        $query->with(['documentType', 'features', 'utilities']);
+        $query->with(['documentType', 'features', 'utilities', 'priceType']);
 
         // Paginate the results
         $perPage = $request->input('per_page', 12);

--- a/Propenty-management-api-main/app/Http/Resources/PropertyResource.php
+++ b/Propenty-management-api-main/app/Http/Resources/PropertyResource.php
@@ -50,6 +50,15 @@ class PropertyResource extends JsonResource
             
             // Pricing - both nested and flat for compatibility
             'price' => $this->price, // Flat price for frontend
+            'priceType' => $this->when($this->relationLoaded('priceType'), function () {
+                return $this->priceType ? [
+                    'key' => $this->priceType->key,
+                    'name_ar' => $this->priceType->name_ar,
+                    'name_en' => $this->priceType->name_en,
+                    'name_ku' => $this->priceType->name_ku,
+                    'localized_name' => $this->priceType->localized_name,
+                ] : null;
+            }),
             'pricing' => [
                 'amount' => $this->price,
                 'formatted' => $this->buildFormattedPrice(),

--- a/afrin-houses-main/src/components/PropertyCard.tsx
+++ b/afrin-houses-main/src/components/PropertyCard.tsx
@@ -16,6 +16,7 @@ import { Button } from './ui/button';
 import { Card, CardContent, CardFooter } from './ui/card';
 import { Badge } from './ui/badge';
 import { useTranslation } from 'react-i18next';
+import i18n from '../i18n';
 import FixedImage from './FixedImage';
 import PropertyImageGallery from './PropertyImageGallery';
 import { processPropertyImages } from '../lib/imageUtils';
@@ -224,7 +225,13 @@ const PropertyCard: React.FC<PropertyCardProps> = ({ property, view = 'grid', us
                     {formatPrice(property.price, property.listingType)}
                   </p>
                   <p className="text-xs text-gray-500 mt-0.5">
-                    {property.priceType ? t(`property.priceTypes.${property.priceType}`) : (property.listingType === 'rent' ? t('property.perMonth') : t('property.totalPrice'))}
+                    {property.priceType ? (
+                      typeof property.priceType === 'object' ? (
+                        i18n.language === 'ar' ? property.priceType.name_ar :
+                        i18n.language === 'ku' ? property.priceType.name_ku :
+                        property.priceType.name_en
+                      ) : t(`property.priceTypes.${property.priceType}`)
+                    ) : (property.listingType === 'rent' ? t('property.perMonth') : t('property.totalPrice'))}
                   </p>
                 </div>
               </div>

--- a/afrin-houses-main/src/pages/PropertyDetails.tsx
+++ b/afrin-houses-main/src/pages/PropertyDetails.tsx
@@ -663,7 +663,13 @@ const PropertyDetails: React.FC = () => {
                       {formatPrice(property.price, property.listingType)}
                     </p>
                     <p className="text-sm text-gray-500 mt-1">
-                      {property.priceType ? t(`property.priceTypes.${property.priceType}`) : (property.listingType === 'rent' ? t('property.perMonth') : t('property.totalPrice'))}
+                      {property.priceType ? (
+                        typeof property.priceType === 'object' ? (
+                          i18n.language === 'ar' ? property.priceType.name_ar :
+                          i18n.language === 'ku' ? property.priceType.name_ku :
+                          property.priceType.name_en
+                        ) : t(`property.priceTypes.${property.priceType}`)
+                      ) : (property.listingType === 'rent' ? t('property.perMonth') : t('property.totalPrice'))}
                     </p>
                   </div>
                 </div>
@@ -1019,7 +1025,13 @@ const PropertyDetails: React.FC = () => {
                       {formatPrice(property.price, property.listingType)}
                     </span>
                     <p className="text-xs text-gray-500 mt-0.5">
-                      {property.priceType ? t(`property.priceTypes.${property.priceType}`) : (property.listingType === 'rent' ? t('property.perMonth') : t('property.totalPrice'))}
+                      {property.priceType ? (
+                        typeof property.priceType === 'object' ? (
+                          i18n.language === 'ar' ? property.priceType.name_ar :
+                          i18n.language === 'ku' ? property.priceType.name_ku :
+                          property.priceType.name_en
+                        ) : t(`property.priceTypes.${property.priceType}`)
+                      ) : (property.listingType === 'rent' ? t('property.perMonth') : t('property.totalPrice'))}
                     </p>
                   </div>
                 </div>

--- a/afrin-houses-main/src/types/index.ts
+++ b/afrin-houses-main/src/types/index.ts
@@ -4,7 +4,14 @@ export interface Property {
   title: string;
   address: string;
   price: number | string;
-  priceType?: 'monthly' | 'yearly' | 'total' | 'fixed' | 'negotiable' | 'finalPrice' | 'folkSaying' | 'lastPrice';
+  priceType?: 'monthly' | 'yearly' | 'total' | 'fixed' | 'negotiable' | 'finalPrice' | 'folkSaying' | 'lastPrice' | {
+    id: number;
+    key: string;
+    name_ar: string;
+    name_en: string;
+    name_ku: string;
+    localized_name: string;
+  };
   listingType: 'rent' | 'sale';
   propertyType: 'apartment' | 'house' | 'condo' | 'townhouse' | 'studio' | 'loft' | 'villa' | 'commercial' | 'land';
   bedrooms: number;
@@ -58,7 +65,14 @@ export interface ExtendedProperty extends Omit<Property, 'property_type' | 'list
   // Original property fields with overrides for consistent naming
   propertyType: string;
   listingType: 'rent' | 'sale';
-  priceType?: 'monthly' | 'yearly' | 'total' | 'fixed' | 'negotiable' | 'finalPrice' | 'folkSaying' | 'lastPrice';
+  priceType?: 'monthly' | 'yearly' | 'total' | 'fixed' | 'negotiable' | 'finalPrice' | 'folkSaying' | 'lastPrice' | {
+    id: number;
+    key: string;
+    name_ar: string;
+    name_en: string;
+    name_ku: string;
+    localized_name: string;
+  };
   squareFootage: number;
   zipCode: string;
   


### PR DESCRIPTION
- Include priceType relation in PropertyController eager loading
- Add priceType resource with multilingual support in PropertyResource
- Extend Property type to support object-based priceType with translations
- Update PropertyCard and PropertyDetails to handle localized priceType display